### PR TITLE
Update ngconnectauthfacebook.php

### DIFF
--- a/classes/ngconnectauthfacebook.php
+++ b/classes/ngconnectauthfacebook.php
@@ -4,7 +4,7 @@ class ngConnectAuthFacebook implements INGConnectAuthInterface
 {
     const AUTH_URI = 'https://www.facebook.com/dialog/oauth?display=%display%&client_id=%app_id%&redirect_uri=%site_url%&scope=%permissions%&state=%state%';
     const TOKEN_URI = 'https://graph.facebook.com/oauth/access_token?client_id=%app_id%&redirect_uri=%site_url%&client_secret=%app_secret%&code=%code%';
-    const GRAPH_URI = 'https://graph.facebook.com/me?%access_token%';
+    const GRAPH_URI = 'https://graph.facebook.com/me?fields=id,name,first_name,last_name,email&%access_token%';
     const PICTURE_URI = 'http://graph.facebook.com/%user_id%/picture';
     const CALLBACK_URI_PART = '/ngconnect/callback/facebook';
 


### PR DESCRIPTION
Facebook does't give us anymore fields first_name, last_name and email by default, these fields are required to create or update the user.